### PR TITLE
update inspire_vs.xsd to import SLD capabilities

### DIFF
--- a/schemas/inspire_vs/1.0/inspire_vs.xsd
+++ b/schemas/inspire_vs/1.0/inspire_vs.xsd
@@ -13,6 +13,10 @@
 16-DEC-2010 Switched to INSPIRE Schema
 -->
 <schema xmlns:inspire_vs="http://inspire.ec.europa.eu/schemas/inspire_vs/1.0" xmlns:inspire_common="http://inspire.ec.europa.eu/schemas/common/1.0" xmlns:wms="http://www.opengis.net/wms" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:xlink="http://www.w3.org/1999/xlink" targetNamespace="http://inspire.ec.europa.eu/schemas/inspire_vs/1.0" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0.1">
+<!-- v1.0.2 of this schema released in INSPIRE schema release v.2022.2.
+       Change performed: SLD capabilities schema import added - non-breaking change - bugfix
+       See https://github.com/INSPIRE-MIF/application-schemas/releases/tag/2022.2 -->
+	
 	<import namespace="http://www.opengis.net/wms" schemaLocation="http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd"/>
 	<import namespace="http://www.opengis.net/sld" schemaLocation="http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd"/>
 	<import namespace="http://inspire.ec.europa.eu/schemas/common/1.0" schemaLocation="../../common/1.0/common.xsd"/>

--- a/schemas/inspire_vs/1.0/inspire_vs.xsd
+++ b/schemas/inspire_vs/1.0/inspire_vs.xsd
@@ -14,6 +14,7 @@
 -->
 <schema xmlns:inspire_vs="http://inspire.ec.europa.eu/schemas/inspire_vs/1.0" xmlns:inspire_common="http://inspire.ec.europa.eu/schemas/common/1.0" xmlns:wms="http://www.opengis.net/wms" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:xlink="http://www.w3.org/1999/xlink" targetNamespace="http://inspire.ec.europa.eu/schemas/inspire_vs/1.0" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0.1">
 	<import namespace="http://www.opengis.net/wms" schemaLocation="http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd"/>
+	<import namespace="http://www.opengis.net/sld" schemaLocation="http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd"/>
 	<import namespace="http://inspire.ec.europa.eu/schemas/common/1.0" schemaLocation="../../common/1.0/common.xsd"/>
 	<element name="ExtendedCapabilities" type="inspire_common:ExtendedCapabilitiesType" substitutionGroup="wms:_ExtendedCapabilities"/>
 </schema>


### PR DESCRIPTION
Issue originally raised here
https://github.com/INSPIRE-MIF/helpdesk-validator/issues/616

The schema inspire_vs.xsd doesn't support SLD Capabilites and WMS GetCapabilities docuemnts will not validate in the ETF Validator.
Based on advice I have added the SLD_Capabilities to the inspire_vs schema