### PR TITLE
Update ElevationGridCoverage.xsd to make endLifespanVersion optional

### DIFF
--- a/schemas/el-cov/4.0/ElevationGridCoverage.xsd
+++ b/schemas/el-cov/4.0/ElevationGridCoverage.xsd
@@ -1,4 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?><schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:base="http://inspire.ec.europa.eu/schemas/base/3.3" xmlns:cvbase="http://inspire.ec.europa.eu/schemas/cvbase/1.0" xmlns:el-bas="http://inspire.ec.europa.eu/schemas/el-bas/4.0" xmlns:el-cov="http://inspire.ec.europa.eu/schemas/el-cov/4.0" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:gmlcov="http://www.opengis.net/gmlcov/1.0" elementFormDefault="qualified" targetNamespace="http://inspire.ec.europa.eu/schemas/el-cov/4.0" version="4.0">
+<?xml version="1.0" encoding="UTF-8"?><schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:base="http://inspire.ec.europa.eu/schemas/base/3.3" xmlns:cvbase="http://inspire.ec.europa.eu/schemas/cvbase/1.0" xmlns:el-bas="http://inspire.ec.europa.eu/schemas/el-bas/4.0" xmlns:el-cov="http://inspire.ec.europa.eu/schemas/el-cov/4.0" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:gmlcov="http://www.opengis.net/gmlcov/1.0" elementFormDefault="qualified" targetNamespace="http://inspire.ec.europa.eu/schemas/el-cov/4.0" version="4.0.1">
+  <!-- v4.0.1 of this schema released in INSPIRE schema release v.2022.2.
+       Change performed: Set ‘endLifespanVersion’ multiplicity to [0..1] - non-breaking change - bugfix
+       See https://github.com/INSPIRE-MIF/application-schemas/releases/tag/2022.2 -->
   <annotation>
     <documentation>-- Name --
 elevation - grid coverage

--- a/schemas/el-cov/4.0/ElevationGridCoverage.xsd
+++ b/schemas/el-cov/4.0/ElevationGridCoverage.xsd
@@ -74,7 +74,7 @@ NOTE 2 The domain extent shall be specified at least in space by using EX_Boundi
               </complexContent>
             </complexType>
           </element>
-          <element name="endLifespanVersion" nillable="true">
+          <element minOccurs="0" name="endLifespanVersion" nillable="true">
             <annotation>
               <documentation>-- Name --
 end lifespan version


### PR DESCRIPTION
Added  minOccurs=0 to the endLifespanVersion definition - related issue https://github.com/INSPIRE-MIF/application-schemas/issues/42