### PR TITLE
Add Croatian language

### DIFF
--- a/schemas/common/1.0/common.xsd
+++ b/schemas/common/1.0/common.xsd
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://inspire.ec.europa.eu/schemas/common/1.0" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" targetNamespace="http://inspire.ec.europa.eu/schemas/common/1.0" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0.1" jaxb:version="2.0">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://inspire.ec.europa.eu/schemas/common/1.0" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" targetNamespace="http://inspire.ec.europa.eu/schemas/common/1.0" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0.2" jaxb:version="2.0">
+<!-- v1.0.2 of this schema released in INSPIRE schema release v.2022.1.
+ Change performed: Added Croatian language - non breaking change.
+ See https://github.com/INSPIRE-MIF/helpdesk-validator/releases/v2022.1 -->
 <!--
 26-APR-2011 1.0.1 Conformity element:
                     Restricted allowed citations to "INSPIRE interoperability of spatial data sets and services", according to the MD regulation,
@@ -31,6 +34,7 @@
 	<xs:include schemaLocation="enums/enum_ger.xsd"/>
 	<xs:include schemaLocation="enums/enum_gle.xsd"/>
 	<xs:include schemaLocation="enums/enum_gre.xsd"/>
+	<xs:include schemaLocation="enums/enum_hrv.xsd"/>
 	<xs:include schemaLocation="enums/enum_hun.xsd"/>
 	<xs:include schemaLocation="enums/enum_ita.xsd"/>
 	<xs:include schemaLocation="enums/enum_lav.xsd"/>
@@ -741,6 +745,7 @@ the resource, and/or access related services.</xs:documentation>
 			<xs:enumeration value="fre"/>
 			<xs:enumeration value="ger"/>
 			<xs:enumeration value="gre"/>
+			<xs:enumeration value="hrv"/>
 			<xs:enumeration value="hun"/>
 			<xs:enumeration value="gle"/>
 			<xs:enumeration value="ita"/>
@@ -1272,6 +1277,8 @@ the resource, and/or access related services.</xs:documentation>
 			<xs:enumeration value="de-AT"/>
 			<xs:enumeration value="el"/>
 			<xs:enumeration value="el-GR"/>
+			<xs:enumeration value="hr"/>
+			<xs:enumeration value="hr-HR"/>
 			<xs:enumeration value="hu"/>
 			<xs:enumeration value="hu-HU"/>
 			<xs:enumeration value="ga"/>

--- a/schemas/common/1.0/enums/enum_hrv.xsd
+++ b/schemas/common/1.0/enums/enum_hrv.xsd
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://inspire.ec.europa.eu/schemas/common/1.0" targetNamespace="http://inspire.ec.europa.eu/schemas/common/1.0" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0.0">
-	<!-- v1.0.2 of this schema released in INSPIRE schema release v.2021.2.
-	 Change performed: Corrected typo in the Dutch INSPIRE theme enumerations XSD - breaking change - bugfix.
-	 See https://github.com/INSPIRE-MIF/helpdesk-validator/releases/v2021.2 -->
 	<xs:complexType name="inspireTheme_hrv">
 		<xs:complexContent>
 			<xs:restriction base="inspireTheme">
@@ -60,9 +57,9 @@
 					<xs:element name="URL">
 						<xs:simpleType>
 							<xs:restriction base="xs:anyURI">
-								<xs:enumeration value="OJ:JOL_2010_323_R_0011_01"/>
-								<xs:enumeration value="CELEX:32010R1089"/>
-								<xs:enumeration value="uriserv:DD.HRV.16.003.FULL"/>
+								<xs:enumeration value="https://eur-lex.europa.eu/legal-content/HR/TXT/PDF/?uri=OJ:JOL_2010_323_R_0011_01"/>
+								<xs:enumeration value="https://eur-lex.europa.eu/legal-content/HR/TXT/PDF/?uri=CELEX:32010R1089"/>
+								<xs:enumeration value="https://eur-lex.europa.eu/legal-content/HR/TXT/PDF/?uri=uriserv:DD.HRV.16.003.FULL"/>
 							</xs:restriction>
 						</xs:simpleType>
 					</xs:element>
@@ -100,9 +97,9 @@
 					<xs:element name="URI" minOccurs="1" maxOccurs="1">
 						<xs:simpleType>
 							<xs:restriction base="xs:anyURI">
-								<xs:enumeration value="https://eur-lex.europa.eu/legal-content/HR/TXT/PDF/?uri=OJ:JOL_2010_323_R_0011_01"/>
-								<xs:enumeration value="https://eur-lex.europa.eu/legal-content/HR/TXT/PDF/?uri=CELEX:32010R1089"/>
-								<xs:enumeration value="https://eur-lex.europa.eu/legal-content/HR/TXT/PDF/?uri=uriserv:DD.HRV.16.003.FULL"/>
+								<xs:enumeration value="OJ:JOL_2010_323_R_0011_01"/>
+								<xs:enumeration value="CELEX:32010R1089"/>
+								<xs:enumeration value="uriserv:DD.HRV.16.003.FULL"/>
 							</xs:restriction>
 						</xs:simpleType>
 					</xs:element>

--- a/schemas/common/1.0/enums/enum_hrv.xsd
+++ b/schemas/common/1.0/enums/enum_hrv.xsd
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://inspire.ec.europa.eu/schemas/common/1.0" targetNamespace="http://inspire.ec.europa.eu/schemas/common/1.0" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0.0">
+	<!-- v1.0.2 of this schema released in INSPIRE schema release v.2021.2.
+	 Change performed: Corrected typo in the Dutch INSPIRE theme enumerations XSD - breaking change - bugfix.
+	 See https://github.com/INSPIRE-MIF/helpdesk-validator/releases/v2021.2 -->
+	<xs:complexType name="inspireTheme_hrv">
+		<xs:complexContent>
+			<xs:restriction base="inspireTheme">
+				<xs:sequence>
+					<xs:element name="OriginatingControlledVocabulary" type="originatingControlledVocabularyGemetInspireThemes" minOccurs="1"/>
+					<xs:element name="KeywordValue">
+						<xs:simpleType>
+							<xs:restriction base="keywordValue">
+								<xs:enumeration value="Adrese"/>
+								<xs:enumeration value="Atmosferski uvjeti"/>
+								<xs:enumeration value="Biogeografske regije"/>
+								<xs:enumeration value="Geografska imena"/>
+								<xs:enumeration value="Geologija"/>
+								<xs:enumeration value="Hidrografija"/>
+								<xs:enumeration value="Izvori energije"/>
+								<xs:enumeration value="Izvori minerala"/>
+								<xs:enumeration value="Katastarske čestice"/>
+								<xs:enumeration value="Komunalne i javne usluge"/>
+								<xs:enumeration value="Koordinatni referentni sustavi"/>
+								<xs:enumeration value="Korištenje zemljišta"/>
+								<xs:enumeration value="Ljudsko zdravlje i sigurnost"/>
+								<xs:enumeration value="Meteorološko-geografska obilježja"/>
+								<xs:enumeration value="Morske regije"/>
+								<xs:enumeration value="Oceanografsko-geografska obilježja"/>
+								<xs:enumeration value="Ortofotosnimke"/>
+								<xs:enumeration value="Područja prirodnih opasnosti"/>
+								<xs:enumeration value="Područja upravljanja/zaštićena područja/uređena područja i jedinice za izvješćivanje"/>
+								<xs:enumeration value="Pokrov zemljišta"/>
+								<xs:enumeration value="Proizvodna i industrijska postrojenja"/>
+								<xs:enumeration value="Prometne mreže"/>
+								<xs:enumeration value="Prostorne jedinice za statistiku"/>
+								<xs:enumeration value="Rasprostranjenost stanovništva – demografija"/>
+								<xs:enumeration value="Rasprostranjenost vrsta"/>
+								<xs:enumeration value="Staništa i biotopi"/>
+								<xs:enumeration value="Sustavi geografskih mreža"/>
+								<xs:enumeration value="Sustavi za nadzor okoliša"/>
+								<xs:enumeration value="Sustavi za poljoprivredu i akvakulturu"/>
+								<xs:enumeration value="Tlo"/>
+								<xs:enumeration value="Upravne jedinice"/>
+								<xs:enumeration value="Visine"/>
+								<xs:enumeration value="Zaštićena područja"/>
+								<xs:enumeration value="Zgrade"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:element>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--Interoperability-->
+	<xs:complexType name="resLocInspireInteroperabilityRegulation_hrv">
+		<xs:complexContent>
+			<xs:restriction base="resourceLocatorType">
+				<xs:sequence>
+					<xs:element name="URL">
+						<xs:simpleType>
+							<xs:restriction base="xs:anyURI">
+								<xs:enumeration value="OJ:JOL_2010_323_R_0011_01"/>
+								<xs:enumeration value="CELEX:32010R1089"/>
+								<xs:enumeration value="uriserv:DD.HRV.16.003.FULL"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:element>
+					<xs:element name="MediaType">
+						<xs:simpleType>
+							<xs:restriction base="mediaType">
+								<xs:enumeration value="application/pdf"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:element>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="citationInspireInteroperabilityRegulation_hrv">
+		<xs:complexContent>
+			<xs:restriction base="citationConformity">
+				<xs:sequence>
+					<xs:element name="Title">
+						<xs:simpleType>
+							<xs:restriction base="notEmptyString">
+								<xs:enumeration value="Uredba Komisije (EU) br. 1089/2010 od 23. studenoga 2010. o provedbi Direktive 2007/2/EZ Europskog parlamenta i Vijeća o međuoperativnosti skupova prostornih podataka i usluga u vezi s prostornim podacima"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:element>
+					<xs:choice>
+						<xs:element name="DateOfPublication">
+							<xs:simpleType>
+								<xs:restriction base="iso8601Date">
+									<xs:enumeration value="2010-12-08"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+					</xs:choice>
+					<xs:element name="URI" minOccurs="1" maxOccurs="1">
+						<xs:simpleType>
+							<xs:restriction base="xs:anyURI">
+								<xs:enumeration value="https://eur-lex.europa.eu/legal-content/HR/TXT/PDF/?uri=OJ:JOL_2010_323_R_0011_01"/>
+								<xs:enumeration value="https://eur-lex.europa.eu/legal-content/HR/TXT/PDF/?uri=CELEX:32010R1089"/>
+								<xs:enumeration value="https://eur-lex.europa.eu/legal-content/HR/TXT/PDF/?uri=uriserv:DD.HRV.16.003.FULL"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:element>
+					<xs:element name="ResourceLocator" type="resLocInspireInteroperabilityRegulation_hrv" minOccurs="1" maxOccurs="1"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+</xs:schema>


### PR DESCRIPTION
Resolves #7

Different types of identifiers are supported (oj, celex and uriserv),
see also https://github.com/INSPIRE-MIF/application-schemas/issues/7#issuecomment-875571105

Note: I changed
http://eur-lex.europa.eu/legal-content/HR/TXT/PDF/?uri=OJ:JOL_2010_323_R_0011_01
to
https://eur-lex.europa.eu/legal-content/HR/TXT/PDF/?uri=OJ:JOL_2010_323_R_0011_01
in comparison with the comment above (so https instead of http).

The themes are taken from https://inspire-geoportal.ec.europa.eu/schemas/inspire/common/1.0/enums/enum_hrv.xsd and match with what is present on https://www.eionet.europa.eu/gemet/hr/inspire-themes/.

The title is copied from the source of https://eur-lex.europa.eu/eli/reg/2010/1089/oj:

![image](https://user-images.githubusercontent.com/11427611/146196721-fcd89a99-9d10-4c54-974a-969397887804.png)
