### PR TITLE
Update CommonTransportElements.xsd to change dataTypes

### DIFF
--- a/schemas/tn/4.0/CommonTransportElements.xsd
+++ b/schemas/tn/4.0/CommonTransportElements.xsd
@@ -82,7 +82,7 @@ Identification of the maintenance authority.</documentation>
               <complexContent>
                 <extension base="gml:AbstractMetadataPropertyType">
                   <sequence>
-                    <element ref="gmd:CI_Citation"/>
+                    <element ref="gmd:CI_ResponsibleParty"/>
                   </sequence>
                 </extension>
               </complexContent>
@@ -158,7 +158,7 @@ Identification of the owning authority.</documentation>
               <complexContent>
                 <extension base="gml:AbstractMetadataPropertyType">
                   <sequence>
-                    <element ref="gmd:CI_Citation"/>
+                    <element ref="gmd:CI_ResponsibleParty"/>
                   </sequence>
                 </extension>
               </complexContent>


### PR DESCRIPTION
Changed the dataType used for MaintenanceAuthority.authority and OwnerAuthority.authority from gmd:CI_Citation to CI_ResponsibleParty