### PR TITLE
LU_PlannedLandUse_Change from 1089 amendment

### DIFF
--- a/schemas/plu/4.0/PlannedLandUse.xsd
+++ b/schemas/plu/4.0/PlannedLandUse.xsd
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:base="http://inspire.ec.europa.eu/schemas/base/3.3" xmlns:base2="http://inspire.ec.europa.eu/schemas/base2/2.0" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:lunom="http://inspire.ec.europa.eu/schemas/lunom/4.0" xmlns:plu="http://inspire.ec.europa.eu/schemas/plu/4.0" xmlns:sc="http://www.interactive-instruments.de/ShapeChange/AppInfo" elementFormDefault="qualified" targetNamespace="http://inspire.ec.europa.eu/schemas/plu/4.0" version="4.0">
+<?xml version="1.0" encoding="UTF-8"?><schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:base="http://inspire.ec.europa.eu/schemas/base/3.3" xmlns:base2="http://inspire.ec.europa.eu/schemas/base2/2.0" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:lunom="http://inspire.ec.europa.eu/schemas/lunom/4.0" xmlns:plu="http://inspire.ec.europa.eu/schemas/plu/4.0" xmlns:sc="http://www.interactive-instruments.de/ShapeChange/AppInfo" elementFormDefault="qualified" targetNamespace="http://inspire.ec.europa.eu/schemas/plu/4.0" version="4.0.1">
   <annotation>
     <documentation>-- Name --
 planned land use</documentation>
@@ -8,7 +8,9 @@ planned land use</documentation>
   <import namespace="http://inspire.ec.europa.eu/schemas/lunom/4.0" schemaLocation="https://inspire.ec.europa.eu/schemas/lunom/4.0/LandUseNomenclature.xsd"/>
   <import namespace="http://www.interactive-instruments.de/ShapeChange/AppInfo" schemaLocation="http://portele.de/ShapeChangeAppinfo.xsd"/>
   <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
-  <!--XML Schema document created by ShapeChange-->
+  <!-- v4.0.1 of this schema released in INSPIRE schema release v.2024.1.
+       Change performed: Fixed the typo in the attribute "backgroudMapURI" of the data type BackgroundMapValue - breaking change - Amendment 1089/2010
+       See https://github.com/INSPIRE-MIF/application-schemas/releases/tag/2024.1 -->
   <element name="BackgroundMapValue" substitutionGroup="gml:AbstractObject" type="plu:BackgroundMapValueType">
     <annotation>
       <documentation>-- Definition --
@@ -31,7 +33,7 @@ Date of the background map used.</documentation>
 Reference to the background map that has been used.</documentation>
         </annotation>
       </element>
-      <element name="backgroudMapURI" nillable="true">
+      <element name="backgroundMapURI" nillable="true">
         <annotation>
           <documentation>-- Name --
 background map URI


### PR DESCRIPTION
Fixed the typo in the attribute "backgroudMapURI" of the data type BackgroundMapValue. Change version and add changelog.