### PR TITLE
fix invalid schema definitions

### DIFF
--- a/schemas/us-net-common/4.0/UtilityNetworksCommon.xsd
+++ b/schemas/us-net-common/4.0/UtilityNetworksCommon.xsd
@@ -917,16 +917,18 @@ Uses the codelist "UtilityNetworkTypeValue" to describe the possible utility net
             </annotation>
           </element>
           <element maxOccurs="unbounded" name="authorityRole">
+            <annotation>
               <documentation>-- Name --
 authority role
 
 -- Definition --
 Parties authorized to manage a utility network, such as maintainers, operators or owners.</documentation>
-         <complexType>
-            <sequence>
-              <element ref="base2:RelatedParty"/>
-            </sequence>
-         </complexType>
+            </annotation>
+            <complexType>
+              <sequence>
+                <element ref="base2:RelatedParty"/>
+              </sequence>
+            </complexType>
           </element>
           <element maxOccurs="unbounded" minOccurs="0" name="utilityFacilityReference" nillable="true">
             <annotation>

--- a/schemas/us-net-common/5.0/UtilityNetworksCommon.xsd
+++ b/schemas/us-net-common/5.0/UtilityNetworksCommon.xsd
@@ -898,16 +898,18 @@ Uses the codelist "UtilityNetworkTypeValue" to describe the possible utility net
             </annotation>
           </element>
           <element maxOccurs="unbounded" name="authorityRole">
+            <annotation>
               <documentation>-- Name --
 authority role
 
 -- Definition --
 Parties authorized to manage a utility network, such as maintainers, operators or owners.</documentation>
-         <complexType>
-            <sequence>
-              <element ref="base2:RelatedParty"/>
-            </sequence>
-         </complexType>
+            </annotation>
+            <complexType>
+              <sequence>
+                <element ref="base2:RelatedParty"/>
+              </sequence>
+            </complexType>
           </element>
           <element maxOccurs="unbounded" minOccurs="0" name="utilityFacilityReference" nillable="true">
             <annotation>

--- a/schemas/us-net-common/5.0/UtilityNetworksCommon.xsd
+++ b/schemas/us-net-common/5.0/UtilityNetworksCommon.xsd
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:act-core="http://inspire.ec.europa.eu/schemas/act-core/4.0" xmlns:base="http://inspire.ec.europa.eu/schemas/base/4.0" xmlns:base2="http://inspire.ec.europa.eu/schemas/base2/2.0" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" xmlns:sc="http://www.interactive-instruments.de/ShapeChange/AppInfo" xmlns:us-govserv="http://inspire.ec.europa.eu/schemas/us-govserv/4.0" xmlns:us-net-common="http://inspire.ec.europa.eu/schemas/us-net-common/5.0" elementFormDefault="qualified" targetNamespace="http://inspire.ec.europa.eu/schemas/us-net-common/5.0" version="5.0">
+<?xml version="1.0" encoding="UTF-8"?><schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:act-core="http://inspire.ec.europa.eu/schemas/act-core/4.0" xmlns:base="http://inspire.ec.europa.eu/schemas/base/4.0" xmlns:base2="http://inspire.ec.europa.eu/schemas/base2/2.0" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" xmlns:sc="http://www.interactive-instruments.de/ShapeChange/AppInfo" xmlns:us-govserv="http://inspire.ec.europa.eu/schemas/us-govserv/5.0" xmlns:us-net-common="http://inspire.ec.europa.eu/schemas/us-net-common/5.0" elementFormDefault="qualified" targetNamespace="http://inspire.ec.europa.eu/schemas/us-net-common/5.0" version="5.0">
   <annotation>
     <documentation>-- Name --
 common utility network elements
@@ -10,7 +10,7 @@ Common Utility Network Elements</documentation>
   <import namespace="http://inspire.ec.europa.eu/schemas/base/4.0" schemaLocation="https://inspire.ec.europa.eu/schemas/base/4.0/BaseTypes.xsd"/>
   <import namespace="http://inspire.ec.europa.eu/schemas/base2/2.0" schemaLocation="https://inspire.ec.europa.eu/schemas/base2/2.0/BaseTypes2.xsd"/>
   <import namespace="http://inspire.ec.europa.eu/schemas/net/4.0" schemaLocation="https://inspire.ec.europa.eu/schemas/net/4.0/Network.xsd"/>
-  <import namespace="http://inspire.ec.europa.eu/schemas/us-govserv/4.0" schemaLocation="https://inspire.ec.europa.eu/schemas/us-govserv/4.0/GovernmentalServices.xsd"/>
+  <import namespace="http://inspire.ec.europa.eu/schemas/us-govserv/5.0" schemaLocation="https://inspire.ec.europa.eu/schemas/us-govserv/5.0/GovernmentalServices.xsd"/>
   <import namespace="http://www.interactive-instruments.de/ShapeChange/AppInfo" schemaLocation="http://portele.de/ShapeChangeAppinfo.xsd"/>
   <import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="http://schemas.opengis.net/iso/19139/20070417/gmd/gmd.xsd"/>
   <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>

--- a/schemas/us-net-ogc/5.0/OilGasChemicalsNetwork.xsd
+++ b/schemas/us-net-ogc/5.0/OilGasChemicalsNetwork.xsd
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:sc="http://www.interactive-instruments.de/ShapeChange/AppInfo" xmlns:us-net-common="http://inspire.ec.europa.eu/schemas/us-net-common/5.0" xmlns:us-net-ogc="http://inspire.ec.europa.eu/schemas/us-net-ogc/5.0" elementFormDefault="qualified" targetNamespace="http://inspire.ec.europa.eu/schemas/us-net-ogc/5.0" version="454
+<?xml version="1.0" encoding="UTF-8"?><schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:sc="http://www.interactive-instruments.de/ShapeChange/AppInfo" xmlns:us-net-common="http://inspire.ec.europa.eu/schemas/us-net-common/5.0" xmlns:us-net-ogc="http://inspire.ec.europa.eu/schemas/us-net-ogc/5.0" elementFormDefault="qualified" targetNamespace="http://inspire.ec.europa.eu/schemas/us-net-ogc/5.0" version="5.0">
+  <annotation>
     <documentation>-- Name --
 oil, gas &amp; chemicals utility network
 


### PR DESCRIPTION
Validation of the schemas in the repository yielded these kind of errors during XML schema validation:

  - ./schemas/us-net-ogc/5.0/OilGasChemicalsNetwork.xsd
    `Problem @ line 0, col 0 : The value of attribute "version" associated with an element type "schema" must not contain the '<' character.`
  - ./schemas/us-net-common/4.0/UtilityNetworksCommon.xsd
    `Problem @ line 920, col 30 : cvc-complex-type.2.4.a: Invalid content was found starting with element 'documentation'. One of '{"http://www.w3.org/2001/XMLSchema":annotation, "http://www.w3.org/2001/XMLSchema":simpleType, "http://www.w3.org/2001/XMLSchema":complexType, "http://www.w3.org/2001/XMLSchema":unique, "http://www.w3.org/2001/XMLSchema":key, "http://www.w3.org/2001/XMLSchema":keyref}' is expected.`
  - ./schemas/us-net-common/5.0/UtilityNetworksCommon.xsd
    `Problem @ line 901, col 30 : cvc-complex-type.2.4.a: Invalid content was found starting with element 'documentation'. One of '{"http://www.w3.org/2001/XMLSchema":annotation, "http://www.w3.org/2001/XMLSchema":simpleType, "http://www.w3.org/2001/XMLSchema":complexType, "http://www.w3.org/2001/XMLSchema":unique, "http://www.w3.org/2001/XMLSchema":key, "http://www.w3.org/2001/XMLSchema":keyref}' is expected.`

The provided changes fix these issues and result in the respective files being valid XML Schemas.