### PR TITLE
Add validation of schemas as check to Pull Requests

### DIFF
--- a/.github/workflows/validate-schemas.yml
+++ b/.github/workflows/validate-schemas.yml
@@ -1,0 +1,27 @@
+name: Validate all XML schemas
+
+on:
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: 17
+
+    - name: Install Groovy
+      uses: sdkman/sdkman-action@b1f9b696c79148b66d3d3a06f7ea801820318d0f
+      with:
+        candidate: groovy
+        version: 4.0.18
+
+    - name: Validate schemas
+      run: |
+        ./validate-all.groovy

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .project
 # Markdown -> HTML preview
 .*.md.html
+
+*.dtd

--- a/validate-all.groovy
+++ b/validate-all.groovy
@@ -1,0 +1,98 @@
+#!/usr/bin/env groovy
+
+import org.xml.sax.ErrorHandler
+import static javax.xml.XMLConstants.W3C_XML_SCHEMA_NS_URI
+import javax.xml.transform.Source
+import javax.xml.transform.stream.StreamSource
+import javax.xml.validation.SchemaFactory
+
+def createValidator(List<URL> xsds) {
+  Source[] sources = new Source[xsds.size()];
+  xsds.eachWithIndex { xsd, i ->
+    sources[i] = new StreamSource(xsd.newInputStream())
+  }
+
+  return SchemaFactory.newInstance(W3C_XML_SCHEMA_NS_URI)
+               .newSchema(sources)
+               .newValidator()
+}
+
+List findProblems(File xml, def vald) {
+  vald.with { validator ->
+    List exceptions = []
+    Closure<Void> handler = { exception -> exceptions << exception }
+    errorHandler = [ warning: handler, fatalError: handler, error: handler ] as ErrorHandler
+    validate(new StreamSource(xml))
+    exceptions
+  }
+}
+
+// schemas for validation
+def schemaUrls = ['https://www.w3.org/2001/XMLSchema.xsd']
+def schemas = []
+schemaUrls.each { schema ->
+  def url
+  if (schema.startsWith('http') || schema.startsWith('file:')) {
+    url = new URL(schema)
+  }
+  else {
+    url = new File(schema).toURL()
+  }
+  schemas.add(url);
+  println "Schema: $url"
+}
+
+// Workaround for issue with references to dtd files being resolved locally - download dtd files to local folder
+new File('XMLSchema.dtd').text = new URL('https://www.w3.org/2001/XMLSchema.dtd').text
+new File('datatypes.dtd').text = new URL('https://www.w3.org/2001/datatypes.dtd').text
+
+def validator = createValidator(schemas)
+
+def errorSchemas = []
+def schemaProblems = [:]
+
+def root = new File('.')
+root.eachFileRecurse { file ->
+  if (file.isFile() && file.name.endsWith('.xsd')) {
+    println "Validating schema file $file"
+
+    try {
+      def problems = findProblems(file, validator)
+
+      problems.each {
+        println "Problem @ line $it.lineNumber, col $it.columnNumber : $it.message"
+      }
+      if (problems.size() > 0) {
+        errorSchemas << file
+        schemaProblems[file] = problems
+        println "\nOverall ${problems.size()} errors."
+      }
+      else {
+        println 'Validation successful.'
+      }
+    } catch (e) {
+      e.printStackTrace()
+      errorSchemas << file
+      schemaProblems[file] = [[lineNumber: 0, columnNumber: 0, message: e.message]]
+    }
+  }
+}
+
+println ""
+
+if (errorSchemas) {
+  println "Schemas with errors:"
+  println ""
+
+  errorSchemas.each { file ->
+    println "  - $file"
+    schemaProblems[file].each {
+      println "    Problem @ line $it.lineNumber, col $it.columnNumber : $it.message"
+    }
+  }
+  // exit with error
+  System.exit(1)
+}
+else {
+  println "All schemas validated successfully"
+}


### PR DESCRIPTION
Maybe you find this useful - I added the script I used for validating the schema definitions as a GitHub Actions workflow that checks every Pull Request. This could help prevent similar problems finding their way into the repository again.

Demonstration examples:

- [Failing validation](https://github.com/stempler/application-schemas/actions/runs/7986845283/job/21808070123)
- [Successful validation](https://github.com/stempler/application-schemas/actions/runs/7986850945/job/21808091511)